### PR TITLE
Adding a node labeling utility script

### DIFF
--- a/Container-Root/hyperpod/ops/eks/node-label-by-type.sh
+++ b/Container-Root/hyperpod/ops/eks/node-label-by-type.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+help(){
+	echo ""
+	echo "Usage: $0 [--dry-run]"
+        echo "       Labels all nodes in the cluster with a node-type label for easier selection"
+	echo "       This adds labels in the format: node.hyperpod.aws/type=<instance-type-prefix>"
+	echo "       For example: node.hyperpod.aws/type=g5, node.hyperpod.aws/type=p4d, etc."
+	echo ""
+	echo "       --dry-run - only show commands that would be executed without actually labeling nodes"
+	echo ""
+}
+
+if [ "$1" == "--help" ]; then
+	help
+	exit 0
+fi
+
+DRY_RUN=false
+if [ "$1" == "--dry-run" ]; then
+	DRY_RUN=true
+fi
+
+echo ""
+echo "Adding node-type labels to all cluster nodes..."
+echo ""
+
+# Get unique instance types in the cluster
+INSTANCE_TYPES=$(kubectl get nodes -o jsonpath='{.items[*].metadata.labels.node\.kubernetes\.io/instance-type}' | tr ' ' '\n' | sort | uniq)
+
+# Process each instance type
+for INSTANCE_TYPE in $INSTANCE_TYPES; do
+    # Extract the instance type prefix (g5, p4d, etc.)
+    TYPE_PREFIX=$(echo $INSTANCE_TYPE | sed -E 's/ml\.//g' | sed -E 's/([a-z]+[0-9]+).*/\1/g')
+    
+    echo "Processing instance type: $INSTANCE_TYPE -> $TYPE_PREFIX"
+    
+    # Get all nodes with this instance type
+    NODES=$(kubectl get nodes -l node.kubernetes.io/instance-type=$INSTANCE_TYPE -o jsonpath='{.items[*].metadata.name}')
+    
+    # Label each node
+    for NODE in $NODES; do
+        CMD="kubectl label node $NODE node.hyperpod.aws/type=$TYPE_PREFIX --overwrite"
+        echo "$CMD"
+        
+        if [ "${DRY_RUN}" != "true" ]; then
+            eval "$CMD"
+        fi
+    done
+done
+
+echo ""
+if [ "${DRY_RUN}" == "true" ]; then
+    echo "Dry run completed. No labels were applied."
+else
+    echo "Node labeling completed. You can now select nodes using:"
+    echo "  kubectl get nodes -l node.hyperpod.aws/type=<type-prefix>"
+    echo "For example:"
+    echo "  kubectl get nodes -l node.hyperpod.aws/type=g5"
+fi
+echo ""

--- a/Container-Root/hyperpod/ops/eks/node-label-family.sh
+++ b/Container-Root/hyperpod/ops/eks/node-label-family.sh
@@ -3,9 +3,9 @@
 help(){
 	echo ""
 	echo "Usage: $0 [--dry-run]"
-        echo "       Labels all nodes in the cluster with a node-type label for easier selection"
-	echo "       This adds labels in the format: node.hyperpod.aws/type=<instance-type-prefix>"
-	echo "       For example: node.hyperpod.aws/type=g5, node.hyperpod.aws/type=p4d, etc."
+        echo "       Labels all nodes in the cluster with a node-family label for easier selection"
+	echo "       This adds labels in the format: node.hyperpod.aws/family=<instance-family>"
+	echo "       For example: node.hyperpod.aws/family=g5, node.hyperpod.aws/family=p4d, etc."
 	echo ""
 	echo "       --dry-run - only show commands that would be executed without actually labeling nodes"
 	echo ""
@@ -22,7 +22,7 @@ if [ "$1" == "--dry-run" ]; then
 fi
 
 echo ""
-echo "Adding node-type labels to all cluster nodes..."
+echo "Adding node-family labels to all cluster nodes..."
 echo ""
 
 # Get unique instance types in the cluster
@@ -30,17 +30,17 @@ INSTANCE_TYPES=$(kubectl get nodes -o jsonpath='{.items[*].metadata.labels.node\
 
 # Process each instance type
 for INSTANCE_TYPE in $INSTANCE_TYPES; do
-    # Extract the instance type prefix (g5, p4d, etc.)
-    TYPE_PREFIX=$(echo $INSTANCE_TYPE | sed -E 's/ml\.//g' | sed -E 's/([a-z]+[0-9]+).*/\1/g')
+    # Extract the instance family (g5, p4d, etc.)
+    INSTANCE_FAMILY=$(echo $INSTANCE_TYPE | sed -E 's/ml\.//g' | sed -E 's/([a-z]+[0-9]+).*/\1/g')
     
-    echo "Processing instance type: $INSTANCE_TYPE -> $TYPE_PREFIX"
+    echo "Processing instance type: $INSTANCE_TYPE -> family: $INSTANCE_FAMILY"
     
     # Get all nodes with this instance type
     NODES=$(kubectl get nodes -l node.kubernetes.io/instance-type=$INSTANCE_TYPE -o jsonpath='{.items[*].metadata.name}')
     
     # Label each node
     for NODE in $NODES; do
-        CMD="kubectl label node $NODE node.hyperpod.aws/type=$TYPE_PREFIX --overwrite"
+        CMD="kubectl label node $NODE node.hyperpod.aws/family=$INSTANCE_FAMILY --overwrite"
         echo "$CMD"
         
         if [ "${DRY_RUN}" != "true" ]; then
@@ -53,9 +53,9 @@ echo ""
 if [ "${DRY_RUN}" == "true" ]; then
     echo "Dry run completed. No labels were applied."
 else
-    echo "Node labeling completed. You can now select nodes using:"
-    echo "  kubectl get nodes -l node.hyperpod.aws/type=<type-prefix>"
+    echo "Node family labeling completed. You can now select nodes using:"
+    echo "  kubectl get nodes -l node.hyperpod.aws/family=<family>"
     echo "For example:"
-    echo "  kubectl get nodes -l node.hyperpod.aws/type=g5"
+    echo "  kubectl get nodes -l node.hyperpod.aws/family=g5"
 fi
 echo ""

--- a/Container-Root/hyperpod/setup/eks/install-kubeps1.sh
+++ b/Container-Root/hyperpod/setup/eks/install-kubeps1.sh
@@ -55,7 +55,7 @@ alias neuron-util='neurontop.sh'
 alias hp='hyperpod'
 alias nm='node-metadata.sh'
 alias nvr='node-versions.sh'
-alias nl-type='node-label-by-type.sh'
+alias nlf='node-label-family.sh'
 
 if [ -f ~/.kubeon ]; then
         source ~/kube-ps1.sh

--- a/Container-Root/hyperpod/setup/eks/install-kubeps1.sh
+++ b/Container-Root/hyperpod/setup/eks/install-kubeps1.sh
@@ -55,6 +55,7 @@ alias neuron-util='neurontop.sh'
 alias hp='hyperpod'
 alias nm='node-metadata.sh'
 alias nvr='node-versions.sh'
+alias nl-type='node-label-by-type.sh'
 
 if [ -f ~/.kubeon ]; then
         source ~/kube-ps1.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding a node labeling utility script that makes it easier to identify node types within a Kubernetes environment. This is particularly useful in heterogeneous cluster environments like the hybrid-hyperpod-eks configuration.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
