### PR TITLE
Generate correct config in case ONSTART_DEEP_HEALTHCHECKS is NULL

### DIFF
--- a/wd/conf/eks/aws-do-hyperpod-eks/generate-config.sh
+++ b/wd/conf/eks/aws-do-hyperpod-eks/generate-config.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Show debug info about the environment files
+echo "==== The content of env_input ===="
+cat ./env_input
+echo "==============================================="
+
+echo "==== The content of env_vars ===="
+cat ./env_vars
+echo "==============================================="
+
 source ./env_input
 source ./env_vars
 
@@ -67,3 +76,20 @@ cat >> hyperpod-config.json << EOL
     "NodeRecovery": "${NODE_RECOVERY}"
 }
 EOL
+
+# Display the generated JSON file
+echo "==== Generated hyperpod-config.json ===="
+cat hyperpod-config.json
+echo "=================================================="
+
+# Validate the JSON if jq is available
+if command -v jq &> /dev/null; then
+    echo "==== Validate output JSON ===="
+    if jq empty hyperpod-config.json 2>/dev/null; then
+        echo "JSON is valid"
+    else
+        echo "ERROR: Invalid JSON"
+        jq empty hyperpod-config.json
+    fi
+    echo "=================================="
+fi

--- a/wd/conf/eks/aws-do-hyperpod-eks/generate-config.sh
+++ b/wd/conf/eks/aws-do-hyperpod-eks/generate-config.sh
@@ -3,6 +3,7 @@
 source ./env_input
 source ./env_vars
 
+# Start writing the JSON
 cat > hyperpod-config.json << EOL
 {
     "ClusterName": "${HYPERPOD_NAME}",
@@ -29,8 +30,16 @@ cat > hyperpod-config.json << EOL
           "OnCreate": "on_create.sh"
         },
         "ExecutionRole": "${EXECUTION_ROLE}",
-        "ThreadsPerCore": 1,
-        "OnStartDeepHealthChecks": ${ONSTART_DEEP_HEALTHCHECKS}
+        "ThreadsPerCore": 1
+EOL
+
+# Conditionally add OnStartDeepHealthChecks only if not empty
+if [ -n "${ONSTART_DEEP_HEALTHCHECKS}" ]; then
+  echo '        ,"OnStartDeepHealthChecks": '${ONSTART_DEEP_HEALTHCHECKS} >> hyperpod-config.json
+fi
+
+# Finish writing the JSON
+cat >> hyperpod-config.json << EOL
       },
       {
         "InstanceGroupName": "worker-group-2",

--- a/wd/conf/eks/aws-do-hyperpod-eks/generate-update-config.sh
+++ b/wd/conf/eks/aws-do-hyperpod-eks/generate-update-config.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
+# Show debug info about the environment files
+echo "==== The content of env_input ===="
+cat ./env_input
+echo "==============================================="
+
+echo "==== The content of env_vars ===="
+cat ./env_vars
+echo "==============================================="
+
 source ./env_input
 source ./env_vars
 
-if [ "$ONSTART_DEEP_HEALTHCHECKS" == "" ]; then
-
+# Start writing the JSON
 cat > hyperpod-update-config.json << EOL
 {
     "ClusterName": "${HYPERPOD_NAME}",
@@ -26,6 +34,14 @@ cat > hyperpod-update-config.json << EOL
         },
         "ExecutionRole": "${EXECUTION_ROLE}",
         "ThreadsPerCore": 1
+EOL
+
+# Conditionally add OnStartDeepHealthChecks only if not empty
+if [ -n "${ONSTART_DEEP_HEALTHCHECKS}" ]; then
+  echo '        ,"OnStartDeepHealthChecks": '${ONSTART_DEEP_HEALTHCHECKS} >> hyperpod-update-config.json
+fi
+
+cat >> hyperpod-update-config.json << EOL
       },
       {
         "InstanceGroupName": "worker-group-2",
@@ -50,52 +66,19 @@ cat > hyperpod-update-config.json << EOL
 }
 EOL
 
-else
+# Display the generated JSON file
+echo "==== Generated hyperpod-update-config.json ===="
+cat hyperpod-update-config.json
+echo "=================================================="
 
-cat > hyperpod-update-config.json << EOL
-{
-    "ClusterName": "${HYPERPOD_NAME}",
-    "InstanceGroups": [
-      {
-        "InstanceGroupName": "worker-group-1",
-        "InstanceType": "${ACCEL_INSTANCE_TYPE}",
-        "InstanceCount": ${ACCEL_COUNT},
-        "InstanceStorageConfigs": [
-          {
-            "EbsVolumeConfig": {
-              "VolumeSizeInGB": ${ACCEL_VOLUME_SIZE}
-            }
-          }
-        ],
-        "LifeCycleConfig": {
-          "SourceS3Uri": "s3://${S3_BUCKET_NAME}",
-          "OnCreate": "on_create.sh"
-        },
-        "ExecutionRole": "${EXECUTION_ROLE}",
-        "ThreadsPerCore": 1,
-        "OnStartDeepHealthChecks": ${ONSTART_DEEP_HEALTHCHECKS}
-      },
-      {
-        "InstanceGroupName": "worker-group-2",
-        "InstanceType": "${GEN_INSTANCE_TYPE}",
-        "InstanceCount": ${GEN_COUNT},
-        "InstanceStorageConfigs": [
-          {
-            "EbsVolumeConfig": {
-              "VolumeSizeInGB": ${GEN_VOLUME_SIZE}
-            }
-          }
-        ],
-        "LifeCycleConfig": {
-          "SourceS3Uri": "s3://${S3_BUCKET_NAME}",
-          "OnCreate": "on_create.sh"
-        },
-        "ExecutionRole": "${EXECUTION_ROLE}",
-        "ThreadsPerCore": 1
-      }
-    ],
-    "NodeRecovery": "${NODE_RECOVERY}"
-}
-EOL
-
+# Validate the JSON if jq is available
+if command -v jq &> /dev/null; then
+    echo "==== Validate output JSON ===="
+    if jq empty hyperpod-update-config.json 2>/dev/null; then
+        echo "JSON is valid"
+    else
+        echo "ERROR: Invalid JSON"
+        jq empty hyperpod-update-config.json
+    fi
+    echo "=================================="
 fi


### PR DESCRIPTION
*Issue #, if available:*
Currently generate-config.sh assumes ONSTART_DEEP_HEALTHCHECKS is always not empty, which means customer cannot generate a config with burn-in disabled. If ONSTART_DEEP_HEALTHCHECKS is empty, generate-config.sh will generate an invalid config. 

*Description of changes:*
Add a check for ONSTART_DEEP_HEALTHCHECKS, and only generate OnStartDeepHealthChecks config when ONSTART_DEEP_HEALTHCHECKS is not empty

*Test*

Tested in local set up with ONSTART_DEEP_HEALTHCHECKS removed from env_input, and generate-config.sh generated the valid cluster config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
