### PR TITLE
Add HyperpodTrainingOperatorServiceRole in CF template

### DIFF
--- a/Container-Root/hyperpod/impl/eks/src/cfn/hyperpod-eks-full-stack-2az.yaml
+++ b/Container-Root/hyperpod/impl/eks/src/cfn/hyperpod-eks-full-stack-2az.yaml
@@ -550,6 +550,35 @@ Resources:
       ResolveConflicts: OVERWRITE
 
 ### ---------------- SageMaker Execution and Service Roles ----------------###
+  HyperpodTrainingOperatorServiceRole:
+    Type: 'AWS::IAM::Role'
+    Condition: CreateEKSCluster
+    Properties:
+      RoleName: !Sub 'hyperpod-training-operator-service-role'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowEksAuthToAssumeRoleForPodIdentity
+            Effect: Allow
+            Principal:
+              Service: pods.eks.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+              - 'sts:TagSession'
+      Path: /
+      Policies:
+        - PolicyName: !Sub 'hyperpod-training-operator-service-policy'
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'sagemaker:DescribeClusterNode'
+                Resource: !Sub 'arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:cluster/*'
+      Tags:
+        - Key: Name
+          Value: !Sub 'hyperpod-training-operator-service-role'
+
   ExecutionRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -663,4 +692,3 @@ Outputs:
   AmazonS3BucketName:
     Description: 'Bucket Name'
     Value: !Ref Bucket
-

--- a/Container-Root/hyperpod/impl/eks/src/cfn/hyperpod-eks-full-stack.yaml
+++ b/Container-Root/hyperpod/impl/eks/src/cfn/hyperpod-eks-full-stack.yaml
@@ -550,6 +550,35 @@ Resources:
       ResolveConflicts: OVERWRITE
 
 ### ---------------- SageMaker Execution and Service Roles ----------------###
+  HyperpodTrainingOperatorServiceRole:
+    Type: 'AWS::IAM::Role'
+    Condition: CreateEKSCluster
+    Properties:
+      RoleName: !Sub 'hyperpod-training-operator-service-role'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowEksAuthToAssumeRoleForPodIdentity
+            Effect: Allow
+            Principal:
+              Service: pods.eks.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+              - 'sts:TagSession'
+      Path: /
+      Policies:
+        - PolicyName: !Sub 'hyperpod-training-operator-service-policy'
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'sagemaker:DescribeClusterNode'
+                Resource: !Sub 'arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:cluster/*'
+      Tags:
+        - Key: Name
+          Value: !Sub 'hyperpod-training-operator-service-role'
+
   ExecutionRole:
     Type: 'AWS::IAM::Role'
     Properties:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add HyperpodTrainingOperatorServiceRole, which is required by https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-eks-operator.html. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
