### PR TITLE
Enable Jinja2 autoescape (ACAT B701 fix)

### DIFF
--- a/Container-Root/hyperpod/deployment/eks/demo/hero/training/fsdp/generate-sbatch-training-files.py
+++ b/Container-Root/hyperpod/deployment/eks/demo/hero/training/fsdp/generate-sbatch-training-files.py
@@ -18,7 +18,8 @@ def list_models(path='models'):
 
 
 def create_sbatch_file(model_name, model_parameters):
-    env = jinja2.Environment(loader=jinja2.FileSystemLoader('slurm'))
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader('slurm'),
+                             autoescape=jinja2.select_autoescape())
     template = env.get_template('training-sub.template')
     content = template.render(MODEL_NAME=model_name,
                               MODEL_PARAMETERS=model_parameters)
@@ -29,7 +30,8 @@ def create_sbatch_file(model_name, model_parameters):
 
 
 def create_kubernetes_file(model_name, model_parameters):
-    env = jinja2.Environment(loader=jinja2.FileSystemLoader('kubernetes'))
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader('kubernetes'),
+                             autoescape=jinja2.select_autoescape())
     template = env.get_template('training_kubernetes.template')
     model_name_dashed = model_name.replace('_', '-')
     content = template.render(MODEL_NAME=model_name_dashed,


### PR DESCRIPTION
## Summary
Resolves AWS AppSec / ACAT Bandit finding `B701` (`jinja2_autoescape_false`) in `Container-Root/hyperpod/deployment/eks/demo/hero/training/fsdp/generate-sbatch-training-files.py`.

Both `jinja2.Environment(...)` constructors were relying on the default `autoescape=False`. This adds `autoescape=jinja2.select_autoescape()` to both, which is the recommended remediation (Aristotle implementation 305).

## Changes
- Line ~21 (`create_sbatch_file`): add `autoescape=jinja2.select_autoescape()`
- Line ~32 (`create_kubernetes_file`): add `autoescape=jinja2.select_autoescape()`

`select_autoescape()` only auto-escapes `.html`/`.xml` templates by default, so the `.template` files rendered here (`.sbatch` / `.yaml`) are functionally unaffected.

## Ticket
AWS AppSec finding ticket: V2270301819